### PR TITLE
Configure application timezone to Tokyo (JST)

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -21,7 +21,7 @@ module Jpwalk
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = "Tokyo"
     # config.eager_load_paths << Rails.root.join("extras")
   end
 end


### PR DESCRIPTION
Fixes ##3: 時刻をJSTで表示 (Display time in JST)

This PR configures the Rails application to display all times in Japan Standard Time by setting `config.time_zone = "Tokyo"`.

## Changes
- Set `config.time_zone = "Tokyo"` in config/application.rb
- This ensures all time displays show Japan Standard Time
- Affects walking session start/end times in views

Generated with [Claude Code](https://claude.ai/code)