### PR TITLE
セッション削除機能を追加

### DIFF
--- a/app/controllers/walking_sessions_controller.rb
+++ b/app/controllers/walking_sessions_controller.rb
@@ -1,5 +1,5 @@
 class WalkingSessionsController < ApplicationController
-  before_action :set_walking_session, only: [ :show, :complete, :pause, :resume, :add_location ]
+  before_action :set_walking_session, only: [ :show, :complete, :pause, :resume, :add_location, :destroy ]
 
   def index
     @walking_sessions = WalkingSession.order(started_at: :desc).limit(10)
@@ -78,6 +78,11 @@ class WalkingSessionsController < ApplicationController
 
   def update
     # Not needed for now
+  end
+
+  def destroy
+    @walking_session.destroy
+    redirect_to root_path, notice: "セッションを削除しました。"
   end
 
   private

--- a/app/views/walking_sessions/index.html.erb
+++ b/app/views/walking_sessions/index.html.erb
@@ -68,7 +68,14 @@
                 </span>
               </div>
             </div>
-            <%= link_to "詳細", session, class: "text-blue-600 hover:text-blue-800" %>
+            <div class="flex space-x-2">
+              <%= link_to "詳細", session, class: "text-blue-600 hover:text-blue-800" %>
+              <%= link_to "削除", session, method: :delete, 
+                  data: { 
+                    confirm: "このセッションを削除してもよろしいですか？\n\n日時: #{session.started_at.strftime('%Y年%m月%d日 %H:%M')}\n時間: #{session.duration_in_minutes}分\n距離: #{session.calculate_distance_from_points.round(2)}km\n\nこの操作は取り消せません。" 
+                  }, 
+                  class: "text-red-600 hover:text-red-800" %>
+            </div>
           </div>
         </div>
       <% end %>

--- a/app/views/walking_sessions/show.html.erb
+++ b/app/views/walking_sessions/show.html.erb
@@ -115,6 +115,11 @@
       <%= link_to "新しいセッションを開始", new_walking_session_path, 
           class: "bg-green-600 text-white px-6 py-3 rounded-lg hover:bg-green-700 transition" %>
     <% end %>
+    <%= link_to "このセッションを削除", @walking_session, method: :delete, 
+        data: { 
+          confirm: "このセッションを削除してもよろしいですか？\n\n日時: #{@walking_session.started_at.strftime('%Y年%m月%d日 %H:%M')}\n時間: #{@walking_session.duration_in_minutes}分\n距離: #{@walking_session.calculate_distance_from_points.round(2)}km\n\nこの操作は取り消せません。" 
+        }, 
+        class: "bg-red-600 text-white px-6 py-3 rounded-lg hover:bg-red-700 transition" %>
   </div>
 </div>
 

--- a/test/controllers/walking_sessions_controller_test.rb
+++ b/test/controllers/walking_sessions_controller_test.rb
@@ -28,12 +28,13 @@ class WalkingSessionsControllerTest < ActionDispatch::IntegrationTest
       interval_type: "slow"
     )
 
-    # Verify we have location points
-    assert_equal 2, session_with_points.location_points.count
+    # Count total location points for this session (includes fixture data)
+    initial_count = session_with_points.location_points.count
+    total_location_points = LocationPoint.count
 
     # Delete the session (should cascade delete location points)
     assert_difference("WalkingSession.count", -1) do
-      assert_difference("LocationPoint.count", -2) do
+      assert_difference("LocationPoint.count", -initial_count) do
         delete walking_session_path(session_with_points)
       end
     end

--- a/test/controllers/walking_sessions_controller_test.rb
+++ b/test/controllers/walking_sessions_controller_test.rb
@@ -3,15 +3,15 @@ require "test_helper"
 class WalkingSessionsControllerTest < ActionDispatch::IntegrationTest
   test "should destroy walking session" do
     session_to_delete = walking_sessions(:completed_session)
-    
-    assert_difference('WalkingSession.count', -1) do
+
+    assert_difference("WalkingSession.count", -1) do
       delete walking_session_path(session_to_delete)
     end
-    
+
     assert_redirected_to root_path
     assert_equal "セッションを削除しました。", flash[:notice]
   end
-  
+
   test "should destroy walking session with location points" do
     session_with_points = walking_sessions(:active_session)
     # Create some location points for this session
@@ -25,32 +25,32 @@ class WalkingSessionsControllerTest < ActionDispatch::IntegrationTest
       longitude: 139.6504,
       recorded_at: 20.minutes.ago
     )
-    
+
     # Verify we have location points
     assert_equal 2, session_with_points.location_points.count
-    
+
     # Delete the session (should cascade delete location points)
-    assert_difference('WalkingSession.count', -1) do
-      assert_difference('LocationPoint.count', -2) do
+    assert_difference("WalkingSession.count", -1) do
+      assert_difference("LocationPoint.count", -2) do
         delete walking_session_path(session_with_points)
       end
     end
-    
+
     assert_redirected_to root_path
     assert_equal "セッションを削除しました。", flash[:notice]
   end
-  
+
   test "should handle deletion of non-existent session" do
     assert_raises(ActiveRecord::RecordNotFound) do
       delete walking_session_path(99999)
     end
   end
-  
+
   test "should redirect to root path after successful deletion" do
     session_to_delete = walking_sessions(:paused_session)
-    
+
     delete walking_session_path(session_to_delete)
-    
+
     assert_redirected_to root_path
     follow_redirect!
     assert_response :success

--- a/test/controllers/walking_sessions_controller_test.rb
+++ b/test/controllers/walking_sessions_controller_test.rb
@@ -18,12 +18,14 @@ class WalkingSessionsControllerTest < ActionDispatch::IntegrationTest
     session_with_points.location_points.create!(
       latitude: 35.6762,
       longitude: 139.6503,
-      recorded_at: 30.minutes.ago
+      recorded_at: 30.minutes.ago,
+      interval_type: "fast"
     )
     session_with_points.location_points.create!(
       latitude: 35.6762,
       longitude: 139.6504,
-      recorded_at: 20.minutes.ago
+      recorded_at: 20.minutes.ago,
+      interval_type: "slow"
     )
 
     # Verify we have location points
@@ -41,9 +43,8 @@ class WalkingSessionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should handle deletion of non-existent session" do
-    assert_raises(ActiveRecord::RecordNotFound) do
-      delete walking_session_path(99999)
-    end
+    delete walking_session_path(99999)
+    assert_response :not_found
   end
 
   test "should redirect to root path after successful deletion" do

--- a/test/controllers/walking_sessions_controller_test.rb
+++ b/test/controllers/walking_sessions_controller_test.rb
@@ -1,7 +1,58 @@
 require "test_helper"
 
 class WalkingSessionsControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  test "should destroy walking session" do
+    session_to_delete = walking_sessions(:completed_session)
+    
+    assert_difference('WalkingSession.count', -1) do
+      delete walking_session_path(session_to_delete)
+    end
+    
+    assert_redirected_to root_path
+    assert_equal "セッションを削除しました。", flash[:notice]
+  end
+  
+  test "should destroy walking session with location points" do
+    session_with_points = walking_sessions(:active_session)
+    # Create some location points for this session
+    session_with_points.location_points.create!(
+      latitude: 35.6762,
+      longitude: 139.6503,
+      recorded_at: 30.minutes.ago
+    )
+    session_with_points.location_points.create!(
+      latitude: 35.6762,
+      longitude: 139.6504,
+      recorded_at: 20.minutes.ago
+    )
+    
+    # Verify we have location points
+    assert_equal 2, session_with_points.location_points.count
+    
+    # Delete the session (should cascade delete location points)
+    assert_difference('WalkingSession.count', -1) do
+      assert_difference('LocationPoint.count', -2) do
+        delete walking_session_path(session_with_points)
+      end
+    end
+    
+    assert_redirected_to root_path
+    assert_equal "セッションを削除しました。", flash[:notice]
+  end
+  
+  test "should handle deletion of non-existent session" do
+    assert_raises(ActiveRecord::RecordNotFound) do
+      delete walking_session_path(99999)
+    end
+  end
+  
+  test "should redirect to root path after successful deletion" do
+    session_to_delete = walking_sessions(:paused_session)
+    
+    delete walking_session_path(session_to_delete)
+    
+    assert_redirected_to root_path
+    follow_redirect!
+    assert_response :success
+  end
 end

--- a/test/fixtures/location_points.yml
+++ b/test/fixtures/location_points.yml
@@ -1,17 +1,17 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
-  walking_session: one
-  latitude: 1.5
-  longitude: 1.5
-  recorded_at: 2025-08-22 23:26:02
+point_one:
+  walking_session: active_session
+  latitude: 35.6762
+  longitude: 139.6503
+  recorded_at: <%= 45.minutes.ago %>
   speed: 1.5
-  interval_type: MyString
+  interval_type: walking
 
-two:
-  walking_session: two
-  latitude: 1.5
-  longitude: 1.5
-  recorded_at: 2025-08-22 23:26:02
-  speed: 1.5
-  interval_type: MyString
+point_two:
+  walking_session: completed_session
+  latitude: 35.6762
+  longitude: 139.6504
+  recorded_at: <%= 2.hours.ago %>
+  speed: 2.0
+  interval_type: walking

--- a/test/fixtures/walking_sessions.yml
+++ b/test/fixtures/walking_sessions.yml
@@ -1,15 +1,22 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
-  started_at: 2025-08-22 23:25:55
-  ended_at: 2025-08-22 23:25:55
-  total_distance: 1.5
-  total_steps: 1
-  status: MyString
+active_session:
+  started_at: <%= 1.hour.ago %>
+  ended_at: null
+  total_distance: 2.5
+  total_steps: 3200
+  status: active
 
-two:
-  started_at: 2025-08-22 23:25:55
-  ended_at: 2025-08-22 23:25:55
-  total_distance: 1.5
-  total_steps: 1
-  status: MyString
+completed_session:
+  started_at: <%= 2.hours.ago %>
+  ended_at: <%= 1.hour.ago %>
+  total_distance: 5.2
+  total_steps: 6800
+  status: completed
+
+paused_session:
+  started_at: <%= 3.hours.ago %>
+  ended_at: null
+  total_distance: 1.8
+  total_steps: 2400
+  status: paused


### PR DESCRIPTION
セッション削除機能と確認ダイアログを実装しました。

## 変更内容
- セッション一覧ページに削除リンクを追加
- セッション詳細ページに削除ボタンを追加
- 確認ダイアログでセッション情報を表示

Closes #5

🤖 Generated with [Claude Code](https://claude.ai/code)