### PR TITLE
feat: Add custom confirmation dialog for session deletion

### DIFF
--- a/app/javascript/controllers/delete_confirmation_controller.js
+++ b/app/javascript/controllers/delete_confirmation_controller.js
@@ -1,0 +1,38 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["modal", "deleteUrl"]
+
+  show(event) {
+    event.preventDefault()
+    this.deleteUrlTarget.value = event.currentTarget.href
+    this.modalTarget.classList.remove("hidden")
+  }
+
+  hide() {
+    this.modalTarget.classList.add("hidden")
+  }
+
+  confirm() {
+    // Create a form and submit it with DELETE method to work with Rails/Turbo
+    const form = document.createElement("form")
+    form.method = "POST"
+    form.action = this.deleteUrlTarget.value
+
+    const csrfToken = document.querySelector('meta[name="csrf-token"]').content
+    const csrfInput = document.createElement("input")
+    csrfInput.type = "hidden"
+    csrfInput.name = "authenticity_token"
+    csrfInput.value = csrfToken
+    form.appendChild(csrfInput)
+
+    const methodInput = document.createElement("input")
+    methodInput.type = "hidden"
+    methodInput.name = "_method"
+    methodInput.value = "delete"
+    form.appendChild(methodInput)
+
+    document.body.appendChild(form)
+    form.submit()
+  }
+}

--- a/app/views/walking_sessions/show.html.erb
+++ b/app/views/walking_sessions/show.html.erb
@@ -122,13 +122,56 @@
   <% end %>
 
   <% if @walking_session.status == 'completed' %>
-    <div class="mt-6 flex justify-center">
+    <div class="mt-6 flex justify-center" data-controller="delete-confirmation">
       <%= link_to "このセッションを削除", @walking_session, 
           data: { 
             "turbo-method": :delete,
-            confirm: "このセッションを削除してもよろしいですか？\n\n日時: #{@walking_session.started_at.strftime('%Y年%m月%d日 %H:%M')}\n時間: #{@walking_session.duration_in_minutes}分\n距離: #{@walking_session.calculate_distance_from_points.round(2)}km\n\nこの操作は取り消せません。" 
+            action: "click->delete-confirmation#show"
           }, 
           class: "bg-red-600 text-white px-6 py-3 rounded-lg hover:bg-red-700 transition" %>
+      
+      <!-- Delete Confirmation Modal -->
+      <div class="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50 hidden" 
+           data-delete-confirmation-target="modal">
+        <div class="relative top-20 mx-auto p-5 border w-96 shadow-lg rounded-md bg-white">
+          <div class="mt-3 text-center">
+            <div class="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-red-100">
+              <svg class="h-6 w-6 text-red-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+            </div>
+            <h3 class="text-lg leading-6 font-medium text-gray-900 mt-4">セッションを削除</h3>
+            <div class="mt-2 px-7 py-3">
+              <p class="text-sm text-gray-500 mb-4">
+                このセッションを削除してもよろしいですか？
+              </p>
+              <div class="text-sm text-gray-700 bg-gray-50 p-3 rounded">
+                <div><strong>日時:</strong> <%= @walking_session.started_at.strftime('%Y年%m月%d日 %H:%M') %></div>
+                <div><strong>時間:</strong> <%= @walking_session.duration_in_minutes %>分</div>
+                <div><strong>距離:</strong> <%= @walking_session.calculate_distance_from_points.round(2) %>km</div>
+              </div>
+              <p class="text-sm text-red-600 mt-3 font-medium">
+                この操作は取り消せません。
+              </p>
+            </div>
+            <div class="items-center px-4 py-3">
+              <div class="flex space-x-3 justify-center">
+                <button data-action="click->delete-confirmation#hide"
+                        class="px-4 py-2 bg-gray-500 text-white text-base font-medium rounded-md shadow-sm hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-gray-300">
+                  キャンセル
+                </button>
+                <button data-action="click->delete-confirmation#confirm"
+                        class="px-4 py-2 bg-red-500 text-white text-base font-medium rounded-md shadow-sm hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-300">
+                  削除する
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      
+      <!-- Hidden field to store delete URL -->
+      <input type="hidden" data-delete-confirmation-target="deleteUrl">
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
Replace native browser confirm dialog with a custom styled modal for session deletion.

## Changes
- Created delete_confirmation_controller.js with Stimulus
- Added Japanese text with session details (date, duration, distance)
- Improved UX with consistent Tailwind CSS styling
- Includes proper CSRF token handling for Rails DELETE requests

Resolves #9

Generated with [Claude Code](https://claude.ai/code)