### PR TITLE
Fix GPS track disconnection issue

### DIFF
--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -118,7 +118,8 @@ export default class extends Controller {
             slowSegments.push([...currentSegment])
           }
         }
-        currentSegment = [coord]
+        // Start new segment with the last point from previous segment to maintain continuity
+        currentSegment = currentSegment.length > 0 ? [currentSegment[currentSegment.length - 1], coord] : [coord]
         currentType = point.interval_type
       } else {
         currentSegment.push(coord)


### PR DESCRIPTION
Fix issue where GPS walking tracks appeared disconnected when transitioning between fast and slow walking segments.

The root cause was in map_controller.js where new segments were started with only the current point when interval_type changed, losing continuity with the previous segment.

Solution: Include the last point from the previous segment when starting a new segment to maintain path continuity.

Fixes #10

Generated with [Claude Code](https://claude.ai/code)